### PR TITLE
feat: API のベース構築 #4

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,3 +1,5 @@
 numpy
 torch
 torchvision
+fastapi
+uvicorn

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .history/
+__pycache__/

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,21 @@
+import sys
+import os
+from fastapi import FastAPI
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from api.routes import vision, health
+
+app = FastAPI()
+
+# ルーターの追加
+app.include_router(vision.router, prefix="/visionai")
+app.include_router(health.router, prefix="")
+
+@app.get("/")
+def root():
+    return {"message": "VisionAI API is running"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8002)

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -1,0 +1,4 @@
+from .vision import *
+from .health import *
+
+__all__ = ["vision", "health"]

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/health")
+def health_check():
+    """
+    API のヘルスチェック
+    """
+    return {"status": "ok"}

--- a/api/routes/vision.py
+++ b/api/routes/vision.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/predict")
+def predict():
+    """
+    VisionAI モデルで画像を処理する
+    """
+    return {"message": "VisionAI prediction endpoint"}

--- a/infra/Dockerfile.api
+++ b/infra/Dockerfile.api
@@ -8,15 +8,16 @@ USER app
 # 3. 作業ディレクトリの設定
 WORKDIR /app
 
+# 5. アプリケーションコードをコピー
+COPY api /app/api
+
 # 4. 依存関係を一括コピー & インストール
-COPY requirements.txt .
+COPY infra/requirements.txt .
 
 USER root
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -r requirements.txt
 USER app
 
-# # 5. アプリケーションコードをコピー
-# COPY api/ .
-
 # 6. FastAPI の起動設定 (uvicorn)
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -2,8 +2,8 @@ services:
   api:
     container_name: visionai-api
     build:
-      context: .
-      dockerfile: Dockerfile.api
+      context: ..
+      dockerfile: infra/Dockerfile.api
     env_file:
       - .env.prob
     command: uvicorn api.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## 概要

FastAPI を用いた API のベースを作成する。また、APIのベースを構築した後に、Dockerで起動して正常にアクセスすることができるかテストを実施する。

## 変更点
✅ Dockerのビルドコンテキストを .. に変更
* `context: . ` だったため、Dockerのビルドコンテキストが カレントディレクトリ (.) だけ になっていた。
* これだと `infra/Dockerfile.api` を使う場合に `infra/` 以外のファイルへアクセスしにくい。
* `context: ..` にすることで、プロジェクト全体をビルドコンテキストに含める ことができる。
   * これにより infra/Dockerfile.api 内で COPY する際、 api/ などのディレクトリにアクセスしやすくなる。

✅ コンテナの動作は変わらない
command: uvicorn api.main:app --host 0.0.0.0 --port 8000 なので、アプリの起動方法は変更なし。
ports: - "8000:8000" でホストの 8000 番ポートをコンテナの 8000 番ポートにマッピングする設定もそのまま。

* `api/main.py` を作成（FastAPI のエントリポイント）
* `routes/vision.py`（Vision API のルート）を作成
* `routes/health.py`（ヘルスチェック）を作成